### PR TITLE
misc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ api.posts.get(5).then(console.log)
 api.posts.get({ search: 'hello' }).then(console.log)
 ```
 
+### Testing
+To run the tests locally, you'll need to add a `test/.env` with your name and token values:
+- `cp test/.env.sample test/.env`
+- `name` is derived from your Rooftop url. Assuming your URL is https://myproject.rooftop.io then **myproject** is your name value
+- `token` can be found <https://[myproject].rooftopcms.io/wp-admin/admin.php?page=rooftop-overview>
+
 ### License & Contributing
 
 - Details on the license [can be found here](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ node api client for [Rooftop CMS](https://www.rooftopcms.com/)
 
 ### Installation
 
-`npm i rooftop -S`
+`npm i rooftop-client -S`
 
 > **Note:** This project only supports Node 6+
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ const Rooftop = {
         headers: { 'Api-Token': opts.apiToken }
         // params: { per_page: 999999 }
       }).wrap(pathPrefix, {
-        prefix: `http://${opts.name}.rooftopcms.io/wp-json/wp/v2/`
+        prefix: `https://${opts.name}.rooftopcms.io/wp-json/wp/v2/`
       })
 
     return new Proxy({

--- a/package.json
+++ b/package.json
@@ -1,18 +1,8 @@
 {
   "name": "rooftop-client",
-  "version": "0.0.1",
   "description": "node api client for rooftop cms",
-  "main": "lib",
-  "scripts": {
-    "test": "ava"
-  },
+  "version": "0.0.1",
   "author": "carrot",
-  "license": "MIT",
-  "devDependencies": {
-    "ava": "0.14.x",
-    "dotenv": "^2.0.0",
-    "standard": "7.x"
-  },
   "ava": {
     "verbose": "true"
   },
@@ -20,7 +10,17 @@
     "joi": "^8.0.5",
     "rest": "^1.3.2"
   },
+  "devDependencies": {
+    "ava": "0.14.x",
+    "dotenv": "^2.0.0",
+    "standard": "7.x"
+  },
   "engines": {
     "node": ">=6.0.0"
+  },
+  "license": "MIT",
+  "main": "lib",
+  "scripts": {
+    "test": "ava"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -28,7 +28,7 @@ test('initializes with correct options', (t) => {
 test('errors when trying to get posts with wrong site', (t) => {
   const api = Rooftop.new({ name: 'foo', apiToken: 'bar' })
   return api.posts.get().catch((res) => {
-    t.is(res.error.toString(), 'Error: getaddrinfo ENOTFOUND foo.rooftopcms.io foo.rooftopcms.io:80')
+    t.is(res.error.toString(), 'Error: getaddrinfo ENOTFOUND foo.rooftopcms.io foo.rooftopcms.io:443')
   })
 })
 


### PR DESCRIPTION
- closes #2 - uses https in api reqs
- closes #1 - documents testing process in readme
- properly identifies `rooftop-client` in installation instructions
