### PR TITLE
Fix issue #6, add template intercepter, update to work with rest 2.0.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ const errorCode = require('rest/interceptor/errorCode')
 const defaultRequest = require('rest/interceptor/defaultRequest')
 const pathPrefix = require('rest/interceptor/pathPrefix')
 const location = require('rest/interceptor/location')
+const template = require('rest/interceptor/template')
 
 /**
  * @class Rooftop
@@ -42,15 +43,17 @@ const Rooftop = {
         // params: { per_page: 999999 }
       }).wrap(pathPrefix, {
         prefix: url
-      })
+      }).wrap(template, { params: {} })
 
     return new Proxy({
       name: opts.name,
       apiToken: opts.apiToken,
       contentType: (name) => {
         return {
-          get: (opts) => {
-            return client(Object.assign({ path: name }, { params: opts }))
+          get: (opts = {}) => {
+            const params = Object.keys(opts).join(',')
+            const pathTemplate = (params === '' ? name : `${name}{?${params}}`)
+            return client(Object.assign({ path: pathTemplate, params: opts }))
               .then((r) => r.entity)
           }
         }

--- a/test/index.js
+++ b/test/index.js
@@ -50,9 +50,15 @@ test('gets data when valid data is provided', (t) => {
 })
 
 test('params passed to get() work correctly', (t) => {
-  return api.posts.get({ search: 'regular' }).then((res) => {
-    t.truthy(res.length === 6)
-    t.is(res[0].slug, 'amazing')
+  return api.posts.get({ per_page: 2 }).then((res) => {
+    t.truthy(res.length === 2)
+  })
+})
+
+test('can handle multiple params passed to get()', (t) => {
+  return api.posts.get({ per_page: 2,  order: 'asc', orderby: 'id', }).then((res) => {
+    t.truthy(res.length === 2)
+    t.is(res[0].id, 125)
   })
 })
 


### PR DESCRIPTION
Ready for review.
- Updated rooftop-client to work with params again, with the update of rest to v2.0.0
- Updated failing params test to pass.
- Added second test for multiple params.
- Example template intercepter query format for reference:
  `{?per_page,order,orderby}`

Closes #6 
