### PR TITLE
New params option for contentTypes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,8 @@ const Rooftop = {
       apiToken: opts.apiToken,
       contentType: (name) => {
         return {
-          get: (opts = { params: {} }) => {
+          get: (opts = {}) => {
+            opts.params = opts.params || {}
             const params = Object.keys(opts.params).join(',')
             const pathTemplate = (params === '' ? name : `${name}{?${params}}`)
             return client(Object.assign({ path: pathTemplate, params: opts.params }))

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ const Rooftop = {
       apiToken: opts.apiToken,
       contentType: (name) => {
         return {
-          get: (opts = {}) => {
+          get: (opts = { params: {} }) => {
             const params = Object.keys(opts.params).join(',')
             const pathTemplate = (params === '' ? name : `${name}{?${params}}`)
             return client(Object.assign({ path: pathTemplate, params: opts.params }))

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,9 +51,9 @@ const Rooftop = {
       contentType: (name) => {
         return {
           get: (opts = {}) => {
-            const params = Object.keys(opts).join(',')
+            const params = Object.keys(opts.params).join(',')
             const pathTemplate = (params === '' ? name : `${name}{?${params}}`)
-            return client(Object.assign({ path: pathTemplate, params: opts }))
+            return client(Object.assign({ path: pathTemplate, params: opts.params }))
               .then((r) => r.entity)
           }
         }

--- a/test/index.js
+++ b/test/index.js
@@ -50,13 +50,13 @@ test('gets data when valid data is provided', (t) => {
 })
 
 test('params passed to get() work correctly', (t) => {
-  return api.posts.get({ per_page: 2 }).then((res) => {
+  return api.posts.get({ params: { per_page: 2 }}).then((res) => {
     t.truthy(res.length === 2)
   })
 })
 
 test('can handle multiple params passed to get()', (t) => {
-  return api.posts.get({ per_page: 2,  order: 'asc', orderby: 'id', }).then((res) => {
+  return api.posts.get({ params: { per_page: 2,  order: 'asc', orderby: 'id', }}).then((res) => {
     t.truthy(res.length === 2)
     t.is(res[0].id, 125)
   })


### PR DESCRIPTION
I'm getting a 'String required for URL encoding' error when using this package because I'm using a template object in the contentTypes array. All contentTypes options are being used in the rest request params instead of only the needed params.

I added a params option so that only per_page, search, etc. will be used in the rest request params.

Example in Spike context:

```
new Rooftop({
  addDataTo: locals,
  url: 'xxx',
  apiToken: 'xxx',
  contentTypes: [{
    name: 'pages',
    params: {
      per_page: 500
    },
    template: {
      path: 'views/_page.sgr',
      output: (page) => { return `${page.slug}.html` }
    }
  }]
})
```

Thoughts?
